### PR TITLE
Refactor number references

### DIFF
--- a/src/routes/models/details.js
+++ b/src/routes/models/details.js
@@ -29,7 +29,7 @@ function createPaymentDetailsSummary (paymentDetails) {
 
   if (paymentDetails.schemes) {
     paymentDetails.schemes.forEach(scheme => {
-      const amount = parseFloat(scheme.amount)
+      const amount = Number.parseFloat(scheme.amount)
       farmerTotal += amount
 
       addSchemeToSummary(summary, scheme)
@@ -80,7 +80,7 @@ function createSummary (paymentDetails) {
 }
 
 function addSchemeToSummary (summary, scheme) {
-  const amount = parseFloat(scheme.amount)
+  const amount = Number.parseFloat(scheme.amount)
   let schemeData = summary.schemes.find(x => x?.name.toLowerCase() === scheme.name.toLowerCase())
   if (!schemeData) {
     const staticSchemeData = getSchemeStaticData(scheme.name)
@@ -117,7 +117,7 @@ function addSchemeActivity (scheme, schemeData) {
     }
   }
 
-  const schemeAmount = parseFloat(scheme.amount)
+  const schemeAmount = Number.parseFloat(scheme.amount)
   schemeData.activity[financialYear].total += schemeAmount
   schemeData.activity[financialYear].readableTotal = getReadableAmount(schemeData.activity[financialYear].total)
   schemeData.activity[financialYear].schemeDetails.push({

--- a/src/routes/models/scheme-payments-by-year.js
+++ b/src/routes/models/scheme-payments-by-year.js
@@ -17,7 +17,7 @@ function getSchemeSummary (schemePaymentsByYear) {
     /* eslint-disable camelcase */
     schemePaymentsByYear[year].forEach(({ scheme, total_amount }) => {
       const schemeData = totalPaymentsBySchemes.find(x => x?.name === scheme)
-      const schemeAmount = Number(parseFloat(total_amount).toFixed(2))
+      const schemeAmount = Number(Number.parseFloat(total_amount).toFixed(2))
 
       if (!schemeData) {
         totalPaymentsBySchemes.push({
@@ -51,7 +51,7 @@ function transformSummary (schemePaymentsByYear) {
   Object.keys(schemePaymentsByYear).forEach(year => {
     const formattedYear = getFormattedYear(year)
     schemePaymentsSummary[formattedYear] = schemePaymentsByYear[year].map(scheme => ({
-      ...scheme, total_amount: getReadableAmount(parseFloat(scheme.total_amount))
+      ...scheme, total_amount: getReadableAmount(Number.parseFloat(scheme.total_amount))
     }))
   })
 


### PR DESCRIPTION
Replace bare `parseFloat` calls with `Number.parseFloat` for consistency with the ESLint `no-restricted-globals` / unicorn-style preference for module-scoped number methods.\n\n### Changes\n- `src/routes/models/details.js` — 3 occurrences\n- `src/routes/models/scheme-payments-by-year.js` — 2 occurrences