### PR TITLE
Replace Wreck with Fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@hapi/inert": "7.1.1",
         "@hapi/scooter": "8.0.0",
         "@hapi/vision": "7.0.3",
-        "@hapi/wreck": "18.1.2",
         "@hapi/yar": "11.0.3",
         "aws-embedded-metrics": "4.2.0",
         "blankie": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@hapi/inert": "7.1.1",
     "@hapi/scooter": "8.0.0",
     "@hapi/vision": "7.0.3",
-    "@hapi/wreck": "18.1.2",
     "@hapi/yar": "11.0.3",
     "aws-embedded-metrics": "4.2.0",
     "blankie": "5.0.0",

--- a/src/api/get-buffer-from-url.js
+++ b/src/api/get-buffer-from-url.js
@@ -1,4 +1,3 @@
-import Wreck from '@hapi/wreck'
 import { buildBackendUrl } from './build-backend-url.js'
 import { logBackendError } from './log-backend-error.js'
 import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
@@ -7,9 +6,9 @@ export async function getBufferFromUrl (url) {
   try {
     const backendUrl = buildBackendUrl(url)
     const headers = await getBackendAuthHeaders()
-    const { payload } = await Wreck.get(backendUrl, { headers })
+    const response = await fetch(backendUrl, { headers })
 
-    return payload
+    return Buffer.from(await response.arrayBuffer())
   } catch (err) {
     logBackendError(err)
     throw err

--- a/src/api/get-stream.js
+++ b/src/api/get-stream.js
@@ -1,4 +1,4 @@
-import Wreck from '@hapi/wreck'
+import { Readable } from 'node:stream'
 import { buildBackendUrl } from './build-backend-url.js'
 import { requestPromise } from './request-promise.js'
 import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
@@ -9,6 +9,6 @@ export async function getStream (path) {
 
   return requestPromise(
     backendUrl,
-    Wreck.request('get', backendUrl, { headers })
+    fetch(backendUrl, { headers }).then((response) => Readable.fromWeb(response.body))
   )
 }

--- a/src/api/get.js
+++ b/src/api/get.js
@@ -8,9 +8,13 @@ export async function get (path) {
 
   return requestPromise(
     backendUrl,
-    fetch(backendUrl, { headers }).then(async (res) => ({
-      res,
-      payload: Buffer.from(await res.arrayBuffer())
-    }))
+    fetch(backendUrl, { headers }).then(async (res) => {
+      if (!res.ok) {
+        const err = new Error(`Backend request failed with status ${res.status}`)
+        err.status = res.status
+        throw err
+      }
+      return res.json()
+    })
   )
 }

--- a/src/api/get.js
+++ b/src/api/get.js
@@ -1,4 +1,3 @@
-import Wreck from '@hapi/wreck'
 import { buildBackendUrl } from './build-backend-url.js'
 import { requestPromise } from './request-promise.js'
 import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
@@ -9,6 +8,9 @@ export async function get (path) {
 
   return requestPromise(
     backendUrl,
-    Wreck.get(backendUrl, { headers })
+    fetch(backendUrl, { headers }).then(async (res) => ({
+      res,
+      payload: Buffer.from(await res.arrayBuffer())
+    }))
   )
 }

--- a/src/api/post-buffer.js
+++ b/src/api/post-buffer.js
@@ -8,7 +8,7 @@ export async function postBuffer (url, payload) {
     const headers = await getBackendAuthHeaders()
     const response = await fetch(backendUrl, {
       method: 'POST',
-      body: payload != null ? JSON.stringify(payload) : undefined,
+      body: payload == null ? undefined : JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json', ...headers }
     })
 

--- a/src/api/post-buffer.js
+++ b/src/api/post-buffer.js
@@ -1,0 +1,20 @@
+import { buildBackendUrl } from './build-backend-url.js'
+import { logBackendError } from './log-backend-error.js'
+import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
+
+export async function postBuffer (url, payload) {
+  try {
+    const backendUrl = buildBackendUrl(url)
+    const headers = await getBackendAuthHeaders()
+    const response = await fetch(backendUrl, {
+      method: 'POST',
+      body: payload != null ? JSON.stringify(payload) : undefined,
+      headers: { 'Content-Type': 'application/json', ...headers }
+    })
+
+    return Buffer.from(await response.arrayBuffer())
+  } catch (err) {
+    logBackendError(err)
+    throw err
+  }
+}

--- a/src/api/post-stream.js
+++ b/src/api/post-stream.js
@@ -1,4 +1,4 @@
-import Wreck from '@hapi/wreck'
+import { Readable } from 'node:stream'
 import { buildBackendUrl } from './build-backend-url.js'
 import { logBackendError } from './log-backend-error.js'
 import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
@@ -9,9 +9,9 @@ export async function postStream (path, payload) {
   try {
     backendUrl = buildBackendUrl(path)
     const headers = await getBackendAuthHeaders()
-    const stream = await Wreck.request('post', backendUrl, { payload, headers })
+    const response = await fetch(backendUrl, { method: 'POST', body: payload, headers })
 
-    return stream
+    return Readable.fromWeb(response.body)
   } catch (err) {
     logBackendError(backendUrl, err)
     throw err

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -10,7 +10,7 @@ export async function post (path, payload) {
     backendUrl,
     fetch(backendUrl, {
       method: 'POST',
-      body: payload != null ? JSON.stringify(payload) : undefined,
+      body: payload == null ? undefined : JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json', ...headers }
     }).then(async (res) => {
       if (!res.ok) {

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -12,9 +12,13 @@ export async function post (path, payload) {
       method: 'POST',
       body: payload != null ? JSON.stringify(payload) : undefined,
       headers: { 'Content-Type': 'application/json', ...headers }
-    }).then(async (res) => ({
-      res,
-      payload: Buffer.from(await res.arrayBuffer())
-    }))
+    }).then(async (res) => {
+      if (!res.ok) {
+        const err = new Error(`Backend request failed with status ${res.status}`)
+        err.status = res.status
+        throw err
+      }
+      return res.json()
+    })
   )
 }

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -1,4 +1,3 @@
-import Wreck from '@hapi/wreck'
 import { buildBackendUrl } from './build-backend-url.js'
 import { requestPromise } from './request-promise.js'
 import { getBackendAuthHeaders } from './get-backend-auth-headers.js'
@@ -9,6 +8,13 @@ export async function post (path, payload) {
 
   return requestPromise(
     backendUrl,
-    Wreck.post(backendUrl, { payload, headers })
+    fetch(backendUrl, {
+      method: 'POST',
+      body: payload != null ? JSON.stringify(payload) : undefined,
+      headers: { 'Content-Type': 'application/json', ...headers }
+    }).then(async (res) => ({
+      res,
+      payload: Buffer.from(await res.arrayBuffer())
+    }))
   )
 }

--- a/src/routes/download/results.js
+++ b/src/routes/download/results.js
@@ -1,5 +1,5 @@
 import http2 from 'node:http2'
-import { post } from '../../api/post.js'
+import { postBuffer } from '../../api/post-buffer.js'
 import { resultsQuery as query } from '../../routes/queries/results.js'
 
 const { constants: httpConstants } = http2
@@ -27,7 +27,7 @@ export const downloadResults = {
         years: typeof years === 'string' ? [years] : years
       }
 
-      const { payload: content } = await post('/file', { searchString, filterBy, sortBy })
+      const content = await postBuffer('/file', { searchString, filterBy, sortBy })
 
       return h
         .response(content)

--- a/src/routes/download/scheme-payments-by-year.js
+++ b/src/routes/download/scheme-payments-by-year.js
@@ -1,13 +1,13 @@
-import { get } from '../../api/get.js'
+import { getBufferFromUrl } from '../../api/get-buffer-from-url.js'
 
 export const downloadSchemePaymentsByYear = {
   method: 'GET',
   path: '/scheme-payments-by-year/file',
   handler: async function (_request, h) {
-    const content = await get('/summary/file')
+    const content = await getBufferFromUrl('/summary/file')
 
     return h
-      .response(content?.payload)
+      .response(content)
       .type('text/csv')
       .header(
         'Content-Disposition',

--- a/src/services/fetch-payment-data.js
+++ b/src/services/fetch-payment-data.js
@@ -9,7 +9,7 @@ export async function fetchPaymentData (
   action,
   limit = config.get('search.limit')
 ) {
-  const response = await post('', {
+  const result = await post('', {
     searchString,
     limit,
     offset,
@@ -17,20 +17,6 @@ export async function fetchPaymentData (
     sortBy,
     action
   })
-
-  if (!response) {
-    return {
-      results: [],
-      total: 0,
-      filterOptions: {
-        schemes: [],
-        years: [],
-        countries: []
-      }
-    }
-  }
-
-  const result = JSON.parse(response.payload)
 
   return {
     results: result.rows,

--- a/src/services/fetch-payment-details.js
+++ b/src/services/fetch-payment-details.js
@@ -3,7 +3,5 @@ import { getUrlParams } from '../api/get-url-params.js'
 
 export async function fetchPaymentDetails (payeeName, partPostcode) {
   const url = getUrlParams(`${payeeName}/${partPostcode}`)
-  const response = await get(url)
-
-  return JSON.parse(response.payload)
+  return get(url)
 }

--- a/src/services/fetch-scheme-payments-by-year.js
+++ b/src/services/fetch-scheme-payments-by-year.js
@@ -3,7 +3,5 @@ import { get } from '../api/get.js'
 
 export async function fetchSchemePaymentsByYear () {
   const url = getUrlParams('summary')
-  const response = await get(url)
-
-  return JSON.parse(response.payload)
+  return get(url)
 }

--- a/src/services/fetch-search-suggestions.js
+++ b/src/services/fetch-search-suggestions.js
@@ -9,11 +9,12 @@ export async function fetchSearchSuggestions (searchString) {
     searchString
   })
 
-  const response = await get(url)
-
-  if (!response || response.res.status === httpConstants.HTTP_STATUS_NOT_FOUND) {
-    return { rows: [], count: 0 }
+  try {
+    return await get(url)
+  } catch (err) {
+    if (err.status === httpConstants.HTTP_STATUS_NOT_FOUND) {
+      return { rows: [], count: 0 }
+    }
+    throw err
   }
-
-  return JSON.parse(response.payload)
 }

--- a/src/services/fetch-search-suggestions.js
+++ b/src/services/fetch-search-suggestions.js
@@ -9,18 +9,11 @@ export async function fetchSearchSuggestions (searchString) {
     searchString
   })
 
-  try {
-    const response = await get(url)
+  const response = await get(url)
 
-    if (!response) {
-      return { rows: [], count: 0 }
-    }
-
-    return JSON.parse(response.payload)
-  } catch (err) {
-    if (err.output?.statusCode === httpConstants.HTTP_STATUS_NOT_FOUND) {
-      return { rows: [], count: 0 }
-    }
-    throw err
+  if (!response || response.res.status === httpConstants.HTTP_STATUS_NOT_FOUND) {
+    return { rows: [], count: 0 }
   }
+
+  return JSON.parse(response.payload)
 }

--- a/test/integration/narrow/routes/download/results.test.js
+++ b/test/integration/narrow/routes/download/results.test.js
@@ -2,12 +2,12 @@ import { describe, beforeAll, afterAll, test, expect, vi } from 'vitest'
 import http2 from 'node:http2'
 import { createServer } from '../../../../../src/server.js'
 import { getOptions } from '../../../../utils/helpers.js'
-import { post } from '../../../../../src/api/post.js'
+import { postBuffer } from '../../../../../src/api/post-buffer.js'
 
 const { constants: httpConstants } = http2
 
-vi.mock('../../../../../src/api/post.js', () => ({
-  post: vi.fn().mockResolvedValue({ payload: 'Sample data in CSV' })
+vi.mock('../../../../../src/api/post-buffer.js', () => ({
+  postBuffer: vi.fn().mockResolvedValue(Buffer.from('Sample data in CSV'))
 }))
 
 describe('Download search results data CSV link', () => {
@@ -56,7 +56,7 @@ describe('Download search results data CSV link', () => {
   })
 
   test('GET /results/file returns status code 500 on underlying error', async () => {
-    post.mockRejectedValueOnce(new Error('Internal Server Error'))
+    postBuffer.mockRejectedValueOnce(new Error('Internal Server Error'))
     response = await server.inject(options)
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR)

--- a/test/integration/narrow/routes/download/scheme-payments-by-year.test.js
+++ b/test/integration/narrow/routes/download/scheme-payments-by-year.test.js
@@ -2,12 +2,12 @@ import { describe, beforeAll, afterAll, test, expect, vi } from 'vitest'
 import http2 from 'node:http2'
 import { createServer } from '../../../../../src/server.js'
 import { getOptions } from '../../../../utils/helpers.js'
-import { get } from '../../../../../src/api/get.js'
+import { getBufferFromUrl } from '../../../../../src/api/get-buffer-from-url.js'
 
 const { constants: httpConstants } = http2
 
-vi.mock('../../../../../src/api/get.js', () => ({
-  get: vi.fn()
+vi.mock('../../../../../src/api/get-buffer-from-url.js', () => ({
+  getBufferFromUrl: vi.fn()
 }))
 
 describe('Download scheme payments by year CSV link', () => {
@@ -29,20 +29,17 @@ describe('Download scheme payments by year CSV link', () => {
     vi.clearAllMocks()
   })
 
-  const content = {
-    response: {},
-    payload: 'Sample data in CSV'
-  }
+  const csvContent = Buffer.from('Sample data in CSV')
 
   test('GET /scheme-payments-by-year/file returns status code 200', async () => {
-    get.mockResolvedValue(content)
+    getBufferFromUrl.mockResolvedValue(csvContent)
     response = await server.inject(options)
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
   })
 
   test('GET /scheme-payments-by-year/file returns attachment', async () => {
-    get.mockResolvedValue(content)
+    getBufferFromUrl.mockResolvedValue(csvContent)
     response = await server.inject(options)
 
     expect(response.headers).toHaveProperty('content-type', 'text/csv; charset=utf-8')
@@ -50,14 +47,14 @@ describe('Download scheme payments by year CSV link', () => {
   })
 
   test('GET /scheme-payments-by-year/file returns expected content', async () => {
-    get.mockResolvedValue(content)
+    getBufferFromUrl.mockResolvedValue(csvContent)
     response = await server.inject(options)
 
-    expect(response.result).toBe(content.payload)
+    expect(response.result).toBe('Sample data in CSV')
   })
 
   test('GET /scheme-payments-by-year/file returns status code 500 on underlying error', async () => {
-    get.mockRejectedValue('Internal server error')
+    getBufferFromUrl.mockRejectedValue('Internal server error')
     response = await server.inject(options)
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR)

--- a/test/unit/api/get-buffer-from-url.test.js
+++ b/test/unit/api/get-buffer-from-url.test.js
@@ -1,10 +1,8 @@
 import { describe, test, expect, vi, afterEach } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { getBufferFromUrl } from '../../../src/api/get-buffer-from-url.js'
 import { buildBackendUrl } from '../../../src/api/build-backend-url.js'
 import { logBackendError } from '../../../src/api/log-backend-error.js'
 
-vi.mock('@hapi/wreck')
 vi.mock('../../../src/api/build-backend-url.js')
 vi.mock('../../../src/api/log-backend-error.js')
 vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
@@ -14,30 +12,33 @@ vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
 describe('getBufferFromUrl', () => {
   afterEach(() => {
     vi.resetAllMocks()
+    vi.unstubAllGlobals()
   })
 
-  test('returns payload when Wreck.get succeeds', async () => {
+  test('returns payload when fetch succeeds', async () => {
     const mockUrl = '/mock/file'
     const backendUrl = 'http://fcp-mpdp-backend/mock/file'
     const mockBuffer = Buffer.from('CSV_CONTENT')
 
     buildBackendUrl.mockReturnValue(backendUrl)
-    Wreck.get.mockResolvedValueOnce({ payload: mockBuffer })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(Uint8Array.from(mockBuffer).buffer)
+    }))
 
     const response = await getBufferFromUrl(mockUrl)
 
     expect(buildBackendUrl).toHaveBeenCalledWith(mockUrl)
-    expect(Wreck.get).toHaveBeenCalledWith(backendUrl, { headers: {} })
+    expect(fetch).toHaveBeenCalledWith(backendUrl, { headers: {} })
     expect(response).toEqual(mockBuffer)
   })
 
-  test('logs and rethrows error when Wreck.get fails', async () => {
+  test('logs and rethrows error when fetch fails', async () => {
     const mockUrl = '/mock/file'
     const backendUrl = 'http://fcp-mpdp-backend/mock/file'
     const mockError = new Error('Mock backend failure')
 
     buildBackendUrl.mockReturnValue(backendUrl)
-    Wreck.get.mockRejectedValueOnce(mockError)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(mockError))
 
     await expect(getBufferFromUrl(mockUrl)).rejects.toThrow(mockError)
     expect(buildBackendUrl).toHaveBeenCalledWith(mockUrl)

--- a/test/unit/api/get-stream.test.js
+++ b/test/unit/api/get-stream.test.js
@@ -1,5 +1,5 @@
 import { vi, describe, beforeEach, afterEach, test, expect } from 'vitest'
-import Wreck from '@hapi/wreck'
+import { Readable } from 'node:stream'
 import { config } from '../../../src/config/config.js'
 import { getStream } from '../../../src/api/get-stream.js'
 
@@ -36,16 +36,16 @@ describe('Backend API: getStream', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   test('service uses the env variable to connect to backend service (stream)', async () => {
-    const mockRequest = vi.fn()
-    vi.spyOn(Wreck, 'request').mockImplementation(mockRequest)
+    const mockReadable = Readable.from(['test'])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: Readable.toWeb(mockReadable) }))
 
     await getStream(route)
 
-    expect(mockRequest).toHaveBeenCalledWith(
-      'get',
+    expect(fetch).toHaveBeenCalledWith(
       `${endpoint}${path}${route}`,
       { headers: {} }
     )
@@ -55,13 +55,11 @@ describe('Backend API: getStream', () => {
     const mockLoggerError = vi.fn()
     mockLogger.error = mockLoggerError
 
-    const mockRequest = vi.fn().mockRejectedValue(new Error('Stream error'))
-    vi.spyOn(Wreck, 'request').mockImplementation(mockRequest)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Stream error')))
 
     await expect(getStream(route)).rejects.toThrow('Stream error')
 
-    expect(mockRequest).toHaveBeenCalledWith(
-      'get',
+    expect(fetch).toHaveBeenCalledWith(
       `${endpoint}${path}${route}`,
       { headers: {} }
     )

--- a/test/unit/api/get.test.js
+++ b/test/unit/api/get.test.js
@@ -39,14 +39,26 @@ describe('Backend API: get', () => {
   })
 
   test('service uses the env variable to connect to backend service', async () => {
+    const mockData = { foo: 'bar' }
     const mockFetch = vi.fn().mockResolvedValue({
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+      ok: true,
+      json: () => Promise.resolve(mockData)
     })
     vi.stubGlobal('fetch', mockFetch)
 
-    await get(route)
+    const result = await get(route)
 
     expect(mockFetch).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { headers: {} })
+    expect(result).toEqual(mockData)
+  })
+
+  test('throws with status when backend returns non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+
+    const err = await get(route).catch(e => e)
+
+    expect(err.message).toMatch('503')
+    expect(err.status).toBe(503)
   })
 
   test('get function handles error', async () => {

--- a/test/unit/api/get.test.js
+++ b/test/unit/api/get.test.js
@@ -1,5 +1,4 @@
 import { vi, describe, beforeEach, afterEach, test, expect } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { config } from '../../../src/config/config.js'
 import { get } from '../../../src/api/get.js'
 
@@ -36,27 +35,30 @@ describe('Backend API: get', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   test('service uses the env variable to connect to backend service', async () => {
-    const mockGet = vi.fn()
-    vi.spyOn(Wreck, 'get').mockImplementation(mockGet)
+    const mockFetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+    })
+    vi.stubGlobal('fetch', mockFetch)
 
     await get(route)
 
-    expect(mockGet).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { headers: {} })
+    expect(mockFetch).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { headers: {} })
   })
 
   test('get function handles error', async () => {
     const mockLoggerError = vi.fn()
     mockLogger.error = mockLoggerError
 
-    const mockGet = vi.fn().mockRejectedValue(null)
-    vi.spyOn(Wreck, 'get').mockImplementation(mockGet)
+    const mockFetch = vi.fn().mockRejectedValue(null)
+    vi.stubGlobal('fetch', mockFetch)
 
     await expect(get(route)).rejects.toThrow()
 
-    expect(mockGet).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { headers: {} })
+    expect(mockFetch).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { headers: {} })
     expect(mockLoggerError).toHaveBeenCalled()
   })
 })

--- a/test/unit/api/post-buffer.test.js
+++ b/test/unit/api/post-buffer.test.js
@@ -1,0 +1,51 @@
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import { postBuffer } from '../../../src/api/post-buffer.js'
+import { buildBackendUrl } from '../../../src/api/build-backend-url.js'
+import { logBackendError } from '../../../src/api/log-backend-error.js'
+
+vi.mock('../../../src/api/build-backend-url.js')
+vi.mock('../../../src/api/log-backend-error.js')
+vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
+  getBackendAuthHeaders: vi.fn().mockReturnValue({})
+}))
+
+describe('postBuffer', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test('returns buffer when fetch succeeds', async () => {
+    const mockUrl = '/mock/file'
+    const backendUrl = 'http://fcp-mpdp-backend/mock/file'
+    const mockContent = Buffer.from('CSV_CONTENT')
+    const payload = { searchString: 'test' }
+
+    buildBackendUrl.mockReturnValue(backendUrl)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(Uint8Array.from(mockContent).buffer)
+    }))
+
+    const result = await postBuffer(mockUrl, payload)
+
+    expect(buildBackendUrl).toHaveBeenCalledWith(mockUrl)
+    expect(fetch).toHaveBeenCalledWith(backendUrl, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'Content-Type': 'application/json' }
+    })
+    expect(result).toEqual(mockContent)
+  })
+
+  test('logs and rethrows error when fetch fails', async () => {
+    const mockUrl = '/mock/file'
+    const backendUrl = 'http://fcp-mpdp-backend/mock/file'
+    const mockError = new Error('Mock backend failure')
+
+    buildBackendUrl.mockReturnValue(backendUrl)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(mockError))
+
+    await expect(postBuffer(mockUrl, {})).rejects.toThrow(mockError)
+    expect(logBackendError).toHaveBeenCalledWith(mockError)
+  })
+})

--- a/test/unit/api/post-stream.test.js
+++ b/test/unit/api/post-stream.test.js
@@ -1,5 +1,5 @@
 import { vi, describe, beforeEach, afterEach, test, expect } from 'vitest'
-import Wreck from '@hapi/wreck'
+import { Readable } from 'node:stream'
 import { config } from '../../../src/config/config.js'
 import { postStream } from '../../../src/api/post-stream.js'
 import { logBackendError } from '../../../src/api/log-backend-error.js'
@@ -33,39 +33,36 @@ describe('Backend API: postStream', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
-  test('calls Wreck.request with correct parameters and returns stream', async () => {
-    const mockStream = { on: vi.fn() }
-    const mockRequest = vi.fn().mockResolvedValue(mockStream)
-    vi.spyOn(Wreck, 'request').mockImplementation(mockRequest)
+  test('calls fetch with correct parameters and returns a Readable stream', async () => {
+    const mockReadable = Readable.from(['test'])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: Readable.toWeb(mockReadable) }))
+
     const result = await postStream(route, { content: 'mock data' })
 
-    expect(mockRequest).toHaveBeenCalledWith(
-      'post',
+    expect(fetch).toHaveBeenCalledWith(
       url,
       {
-        payload: {
-          content: 'mock data'
-        },
+        method: 'POST',
+        body: { content: 'mock data' },
         headers: {}
       }
     )
 
-    expect(result).toBe(mockStream)
+    expect(result).toBeInstanceOf(Readable)
   })
 
-  test('logs error and rethrows when Wreck.request rejects', async () => {
+  test('logs error and rethrows when fetch rejects', async () => {
     const mockError = new Error('Test stream error')
-    const mockRequest = vi.fn().mockRejectedValue(mockError)
-    vi.spyOn(Wreck, 'request').mockImplementation(mockRequest)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(mockError))
 
     await expect(postStream(route, {})).rejects.toThrow('Test stream error')
 
-    expect(mockRequest).toHaveBeenCalledWith(
-      'post',
+    expect(fetch).toHaveBeenCalledWith(
       url,
-      { payload: {}, headers: {} }
+      { method: 'POST', body: {}, headers: {} }
     )
 
     expect(logBackendError).toHaveBeenCalledWith(url, mockError)

--- a/test/unit/api/post.test.js
+++ b/test/unit/api/post.test.js
@@ -1,5 +1,4 @@
 import { vi, describe, beforeEach, afterEach, test, expect } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { config } from '../../../src/config/config.js'
 import { post } from '../../../src/api/post.js'
 
@@ -36,27 +35,36 @@ describe('Backend API: post', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   test('service uses the env variable to connect to backend service', async () => {
-    const mockPost = vi.fn()
-    vi.spyOn(Wreck, 'post').mockImplementation(mockPost)
+    const mockFetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+    })
+    vi.stubGlobal('fetch', mockFetch)
 
     await post(route, {})
 
-    expect(mockPost).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { payload: {}, headers: {} })
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${endpoint}${path}${route}`,
+      { method: 'POST', body: JSON.stringify({}), headers: { 'Content-Type': 'application/json' } }
+    )
   })
 
   test('post function handles error', async () => {
     const mockLoggerError = vi.fn()
     mockLogger.error = mockLoggerError
 
-    const mockPost = vi.fn().mockRejectedValue(new Error('Test error'))
-    vi.spyOn(Wreck, 'post').mockImplementation(mockPost)
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Test error'))
+    vi.stubGlobal('fetch', mockFetch)
 
     await expect(post(route, {})).rejects.toThrow('Test error')
 
-    expect(mockPost).toHaveBeenCalledWith(`${endpoint}${path}${route}`, { payload: {}, headers: {} })
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${endpoint}${path}${route}`,
+      expect.objectContaining({ method: 'POST' })
+    )
     expect(mockLoggerError).toHaveBeenCalled()
   })
 })

--- a/test/unit/api/post.test.js
+++ b/test/unit/api/post.test.js
@@ -39,17 +39,29 @@ describe('Backend API: post', () => {
   })
 
   test('service uses the env variable to connect to backend service', async () => {
+    const mockData = { foo: 'bar' }
     const mockFetch = vi.fn().mockResolvedValue({
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+      ok: true,
+      json: () => Promise.resolve(mockData)
     })
     vi.stubGlobal('fetch', mockFetch)
 
-    await post(route, {})
+    const result = await post(route, {})
 
     expect(mockFetch).toHaveBeenCalledWith(
       `${endpoint}${path}${route}`,
       { method: 'POST', body: JSON.stringify({}), headers: { 'Content-Type': 'application/json' } }
     )
+    expect(result).toEqual(mockData)
+  })
+
+  test('throws with status when backend returns non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 422 }))
+
+    const err = await post(route, {}).catch(e => e)
+
+    expect(err.message).toMatch('422')
+    expect(err.status).toBe(422)
   })
 
   test('post function handles error', async () => {

--- a/test/unit/services/fetch-payment-data.test.js
+++ b/test/unit/services/fetch-payment-data.test.js
@@ -1,8 +1,9 @@
 import { describe, beforeEach, afterEach, test, expect, vi } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { fetchPaymentData } from '../../../src/services/fetch-payment-data.js'
+import * as apiPost from '../../../src/api/post.js'
 import { config } from '../../../src/config/config.js'
 
+vi.mock('../../../src/api/post.js')
 vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
   getBackendAuthHeaders: vi.fn().mockReturnValue({})
 }))
@@ -37,8 +38,7 @@ describe('fetchPaymentData', () => {
   })
 
   test('fetchPaymentData return empty results list if no response is received', async () => {
-    const mockPost = vi.fn().mockResolvedValue(null)
-    vi.spyOn(Wreck, 'post').mockImplementation(mockPost)
+    apiPost.post.mockResolvedValue(null)
 
     const searchString = '__TEST_STRING__'
     const offset = 0
@@ -52,19 +52,17 @@ describe('fetchPaymentData', () => {
       filterOptions: {}
     })
 
-    expect(mockPost).toHaveBeenCalledWith(`${endpoint}${path}`, { payload: { filterBy, limit: 20, offset, searchString, sortBy }, headers: {} })
+    expect(apiPost.post).toHaveBeenCalledWith('', { filterBy, limit: 20, offset, searchString, sortBy, action: undefined })
   })
 
   test('getPaymentData returns results from the payload in the right format', async () => {
-    const mockPost = vi.fn().mockResolvedValue({
+    apiPost.post.mockResolvedValue({
       payload: JSON.stringify({
         rows: mockData,
         count: 1,
         filterOptions: {}
       })
     })
-
-    vi.spyOn(Wreck, 'post').mockImplementation(mockPost)
 
     const searchString = '__TEST_STRING__'
     const offset = 0
@@ -78,18 +76,16 @@ describe('fetchPaymentData', () => {
       filterOptions: {}
     })
 
-    expect(mockPost).toHaveBeenCalledWith(`${endpoint}${path}`, { payload: { filterBy, limit: 20, offset, searchString, sortBy }, headers: {} })
+    expect(apiPost.post).toHaveBeenCalledWith('', { filterBy, limit: 20, offset, searchString, sortBy, action: undefined })
   })
 
   test('getPaymentData called with download action', async () => {
-    const mockPost = vi.fn().mockResolvedValue({
+    apiPost.post.mockResolvedValue({
       payload: JSON.stringify({
         rows: mockData,
         count: 1
       })
     })
-
-    vi.spyOn(Wreck, 'post').mockImplementation(mockPost)
 
     const searchString = '__TEST_STRING__'
     const offset = 0
@@ -103,6 +99,6 @@ describe('fetchPaymentData', () => {
       total: mockData.length
     })
 
-    expect(mockPost).toHaveBeenCalledWith(`${endpoint}${path}`, { payload: { filterBy, limit: 20, offset, searchString, sortBy, action }, headers: {} })
+    expect(apiPost.post).toHaveBeenCalledWith('', { filterBy, limit: 20, offset, searchString, sortBy, action })
   })
 })

--- a/test/unit/services/fetch-payment-data.test.js
+++ b/test/unit/services/fetch-payment-data.test.js
@@ -38,30 +38,21 @@ describe('fetchPaymentData', () => {
   })
 
   test('fetchPaymentData return empty results list if no response is received', async () => {
-    apiPost.post.mockResolvedValue(null)
+    apiPost.post.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }))
 
     const searchString = '__TEST_STRING__'
     const offset = 0
     const sortBy = 'score'
     const filterBy = { schemes: [] }
-    const res = await fetchPaymentData(searchString, offset, filterBy, sortBy)
 
-    expect(res).toMatchObject({
-      results: [],
-      total: 0,
-      filterOptions: {}
-    })
-
-    expect(apiPost.post).toHaveBeenCalledWith('', { filterBy, limit: 20, offset, searchString, sortBy, action: undefined })
+    await expect(fetchPaymentData(searchString, offset, filterBy, sortBy)).rejects.toThrow()
   })
 
   test('getPaymentData returns results from the payload in the right format', async () => {
     apiPost.post.mockResolvedValue({
-      payload: JSON.stringify({
-        rows: mockData,
-        count: 1,
-        filterOptions: {}
-      })
+      rows: mockData,
+      count: 1,
+      filterOptions: {}
     })
 
     const searchString = '__TEST_STRING__'
@@ -81,10 +72,8 @@ describe('fetchPaymentData', () => {
 
   test('getPaymentData called with download action', async () => {
     apiPost.post.mockResolvedValue({
-      payload: JSON.stringify({
-        rows: mockData,
-        count: 1
-      })
+      rows: mockData,
+      count: 1
     })
 
     const searchString = '__TEST_STRING__'

--- a/test/unit/services/fetch-payment-details.test.js
+++ b/test/unit/services/fetch-payment-details.test.js
@@ -37,7 +37,7 @@ describe('fetchPaymentDetails', () => {
   }]
 
   test('fetchPaymentDetails returns results', async () => {
-    apiGet.get.mockResolvedValue({ payload: JSON.stringify(mockData) })
+    apiGet.get.mockResolvedValue(mockData)
 
     const payeeName = '__PAYEE_NAME__'
     const partPostcode = '__POST_CODE'

--- a/test/unit/services/fetch-payment-details.test.js
+++ b/test/unit/services/fetch-payment-details.test.js
@@ -1,9 +1,10 @@
 import { describe, beforeEach, afterEach, test, expect, vi } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { config } from '../../../src/config/config.js'
 import { getUrlParams } from '../../../src/api/get-url-params.js'
 import { fetchPaymentDetails } from '../../../src/services/fetch-payment-details.js'
+import * as apiGet from '../../../src/api/get.js'
 
+vi.mock('../../../src/api/get.js')
 vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
   getBackendAuthHeaders: vi.fn().mockReturnValue({})
 }))
@@ -36,11 +37,7 @@ describe('fetchPaymentDetails', () => {
   }]
 
   test('fetchPaymentDetails returns results', async () => {
-    const mockGet = vi.fn().mockResolvedValue({
-      payload: JSON.stringify(mockData)
-    })
-
-    vi.spyOn(Wreck, 'get').mockImplementation(mockGet)
+    apiGet.get.mockResolvedValue({ payload: JSON.stringify(mockData) })
 
     const payeeName = '__PAYEE_NAME__'
     const partPostcode = '__POST_CODE'
@@ -49,7 +46,6 @@ describe('fetchPaymentDetails', () => {
     expect(response).toMatchObject(mockData)
 
     const newRoute = getUrlParams(`${payeeName}/${partPostcode}`)
-
-    expect(mockGet).toHaveBeenCalledWith(`${endpoint}${path}${newRoute}`, { headers: {} })
+    expect(apiGet.get).toHaveBeenCalledWith(newRoute)
   })
 })

--- a/test/unit/services/fetch-scheme-payments-by-year.test.js
+++ b/test/unit/services/fetch-scheme-payments-by-year.test.js
@@ -17,27 +17,21 @@ describe('fetchSchemePaymentsByYear', () => {
   })
 
   test('should call getUrlParams with "summary" and return parsed payload', async () => {
+    const mockData = { year: 2023, amount: 1000 }
     getUrlParams.mockReturnValue('/test/url')
-    get.mockResolvedValue({ payload: '{ "year": 2023, "amount": 1000 }' })
+    get.mockResolvedValue(mockData)
 
     const result = await fetchSchemePaymentsByYear()
 
     expect(getUrlParams).toHaveBeenCalledWith('summary')
     expect(get).toHaveBeenCalledWith('/test/url')
-    expect(result).toEqual({ year: 2023, amount: 1000 })
+    expect(result).toEqual(mockData)
   })
 
-  test('should return null if get returns a falsy value', async () => {
+  test('should throw if get rejects', async () => {
     getUrlParams.mockReturnValue('/test/url')
-    get.mockResolvedValue(null)
+    get.mockRejectedValue(new Error('Backend error'))
 
-    await expect(fetchSchemePaymentsByYear()).rejects.toThrow()
-  })
-
-  test('should throw if payload is not valid JSON', async () => {
-    getUrlParams.mockReturnValue('/test/url')
-    get.mockResolvedValue({ payload: 'invalid-json' })
-
-    await expect(fetchSchemePaymentsByYear()).rejects.toThrow(SyntaxError)
+    await expect(fetchSchemePaymentsByYear()).rejects.toThrow('Backend error')
   })
 })

--- a/test/unit/services/fetch-search-suggestions.test.js
+++ b/test/unit/services/fetch-search-suggestions.test.js
@@ -31,7 +31,7 @@ describe('fetchSearchSuggestions', () => {
   })
 
   test('should return default object if no response is received', async () => {
-    apiGet.get.mockResolvedValue(null)
+    apiGet.get.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }))
 
     const searchString = '__PAYEE_NAME__'
     const res = await fetchSearchSuggestions(searchString)
@@ -43,7 +43,7 @@ describe('fetchSearchSuggestions', () => {
   })
 
   test('should return results', async () => {
-    apiGet.get.mockResolvedValue({ res: { status: 200 }, payload: JSON.stringify(mockSuggestions) })
+    apiGet.get.mockResolvedValue(mockSuggestions)
 
     const searchString = '__TEST_STRING__'
     const res = await fetchSearchSuggestions(searchString)
@@ -55,7 +55,7 @@ describe('fetchSearchSuggestions', () => {
   })
 
   test('should return empty results when backend returns 404', async () => {
-    apiGet.get.mockResolvedValue({ res: { status: 404 }, payload: Buffer.from('') })
+    apiGet.get.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }))
 
     const res = await fetchSearchSuggestions('__NO_RESULTS__')
 

--- a/test/unit/services/fetch-search-suggestions.test.js
+++ b/test/unit/services/fetch-search-suggestions.test.js
@@ -1,10 +1,11 @@
 import { describe, afterEach, beforeEach, test, expect, vi } from 'vitest'
-import Wreck from '@hapi/wreck'
 import { fetchSearchSuggestions } from '../../../src/services/fetch-search-suggestions.js'
 import { getUrlParams } from '../../../src/api/get-url-params.js'
 import { config } from '../../../src/config/config.js'
 import mockSuggestions from '../../data/mock-suggestions.js'
+import * as apiGet from '../../../src/api/get.js'
 
+vi.mock('../../../src/api/get.js')
 vi.mock('../../../src/api/get-backend-auth-headers.js', () => ({
   getBackendAuthHeaders: vi.fn().mockReturnValue({})
 }))
@@ -30,8 +31,7 @@ describe('fetchSearchSuggestions', () => {
   })
 
   test('should return default object if no response is received', async () => {
-    const mockGet = vi.fn().mockResolvedValue(null)
-    vi.spyOn(Wreck, 'get').mockImplementation(mockGet)
+    apiGet.get.mockResolvedValue(null)
 
     const searchString = '__PAYEE_NAME__'
     const res = await fetchSearchSuggestions(searchString)
@@ -39,16 +39,11 @@ describe('fetchSearchSuggestions', () => {
     expect(res).toEqual({ rows: [], count: 0 })
 
     const newRoute = getUrlParams('search', { searchString })
-
-    expect(mockGet).toHaveBeenCalledWith(`${endpoint}${path}${newRoute}`, { headers: {} })
+    expect(apiGet.get).toHaveBeenCalledWith(newRoute)
   })
 
   test('should return results', async () => {
-    const mockGet = vi.fn().mockResolvedValue({
-      payload: JSON.stringify(mockSuggestions)
-    })
-
-    vi.spyOn(Wreck, 'get').mockImplementation(mockGet)
+    apiGet.get.mockResolvedValue({ res: { status: 200 }, payload: JSON.stringify(mockSuggestions) })
 
     const searchString = '__TEST_STRING__'
     const res = await fetchSearchSuggestions(searchString)
@@ -56,15 +51,11 @@ describe('fetchSearchSuggestions', () => {
     expect(res).toMatchObject(mockSuggestions)
 
     const newRoute = getUrlParams('search', { searchString })
-
-    expect(mockGet).toHaveBeenCalledWith(`${endpoint}${path}${newRoute}`, { headers: {} })
+    expect(apiGet.get).toHaveBeenCalledWith(newRoute)
   })
 
   test('should return empty results when backend returns 404', async () => {
-    const notFoundError = Object.assign(new Error('Not Found'), {
-      output: { statusCode: 404 }
-    })
-    vi.spyOn(Wreck, 'get').mockRejectedValue(notFoundError)
+    apiGet.get.mockResolvedValue({ res: { status: 404 }, payload: Buffer.from('') })
 
     const res = await fetchSearchSuggestions('__NO_RESULTS__')
 
@@ -72,10 +63,7 @@ describe('fetchSearchSuggestions', () => {
   })
 
   test('should rethrow non-404 errors', async () => {
-    const serverError = Object.assign(new Error('Internal Server Error'), {
-      output: { statusCode: 500 }
-    })
-    vi.spyOn(Wreck, 'get').mockRejectedValue(serverError)
+    apiGet.get.mockRejectedValue(new Error('Internal Server Error'))
 
     await expect(fetchSearchSuggestions('__ERROR__')).rejects.toThrow('Internal Server Error')
   })


### PR DESCRIPTION
Replaces `@hapi/wreck` with Node.js 24's built-in `fetch` API. Drops the dependency from `package.json` and updates all unit tests.