### PR TITLE
Update dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build:frontend": "vite build",
-    "dev": "npm-run-all2 --parallel frontend:watch server:watch",
-    "dev:debug": "npm-run-all2 --parallel frontend:watch server:debug",
+    "dev": "vite build --mode development && npm-run-all2 --parallel frontend:watch server:watch",
+    "dev:debug": "vite build --mode development && npm-run-all2 --parallel frontend:watch server:debug",
     "docker:build": "docker compose --profile app build",
     "docker:dev": "docker compose --profile app up",
     "frontend:watch": "vite build --mode development --watch",


### PR DESCRIPTION
## Problem

On a clean clone (or after deleting `.public`), `npm run dev` fails immediately with:

```
Error: ENOENT: no such file or directory, stat '.public/assets-manifest.json'
```

Node's `--watch-path` calls `stat()` on every path at startup and throws if any don't exist. `.public` is gitignored so it's never present on a fresh checkout. `npm-run-all2 --parallel` starts the vite watcher and the node server simultaneously, creating a race condition where the server starts before vite has had a chance to create the manifest.

## Fix

Prefix `dev` and `dev:debug` with a sequential dev-mode vite build so `assets-manifest.json` exists before `server:watch` starts:

```
vite build --mode development && npm-run-all2 --parallel frontend:watch server:watch
```

The initial build uses the same mode as the watcher (`development`), so the watcher's first incremental pass is fast. Total added startup time is one dev-mode vite build (~3–5s).

## npm audit

`npm audit` reports 0 vulnerabilities.