### PR TITLE
Order year filter

### DIFF
--- a/src/common/utils/get-financial-year-summary.js
+++ b/src/common/utils/get-financial-year-summary.js
@@ -1,4 +1,4 @@
-function sortFinancialYears (financialYears) {
+export function sortFinancialYears (financialYears) {
   return financialYears.sort((a, b) => {
     const [, endYearA] = a.split('/')
     const [, endYearB] = b.split('/')

--- a/src/routes/models/search/results.js
+++ b/src/routes/models/search/results.js
@@ -6,6 +6,7 @@ import { sortByItems } from '../../../data/sort-by-items.js'
 import { getAllSchemeNames } from '../../../common/utils/get-all-scheme-names.js'
 import { getRelatedContentLinks } from '../../../common/utils/related-content.js'
 import { getSafeRedirect } from '../../../common/utils/get-safe-redirect.js'
+import { sortFinancialYears } from '../../../common/utils/get-financial-year-summary.js'
 
 function getTags (query, { counties }) {
   const tags = {
@@ -106,7 +107,7 @@ function getFilters (query, filterOptions) {
 
 const getSchemes = schemes => schemes?.length ? schemes : getAllSchemeNames()
 
-const getYears = years => (years?.length ? years : staticYears)
+const getYears = years => sortFinancialYears(years?.length ? years : staticYears)
 
 const getCounties = counties => counties?.length ? counties.sort((a, b) => a.localeCompare(b)) : staticCounties
 

--- a/test/unit/routes/models/search/results.test.js
+++ b/test/unit/routes/models/search/results.test.js
@@ -109,7 +109,33 @@ describe('resultsModel', () => {
 
     expect(result.pageTitle).toBe('Results for ‘farms’')
   })
+  test('should return years filter items in ascending financial year order', async () => {
+    fetchPaymentData.mockResolvedValue({
+      results: [{ id: 1, total_amount: 100, payee_name: 'John Doe' }],
+      total: 1,
+      filterOptions: {
+        schemes: [],
+        years: ['23/24', '21/22', '22/23'],
+        counties: []
+      }
+    })
 
+    const request = {
+      query: {
+        searchString: 'farms',
+        sortBy: 'score',
+        page: 1,
+        schemes: [],
+        years: [],
+        counties: []
+      },
+      headers: { referer: '/previous-page' }
+    }
+
+    const result = await resultsModel(request, false)
+
+    expect(result.filters.years.items.map(item => item.value)).toEqual(['21/22', '22/23', '23/24'])
+  })
   test('should generate correct pagination when multiple pages exist', async () => {
     fetchPaymentData.mockResolvedValue({
       results: Array(15).fill({ id: 1, total_amount: 50 }),


### PR DESCRIPTION
The financial years filter on the search results page was unordered because the backend returns years in search-result order with no explicit sort.

## Changes

- `src/common/utils/get-financial-year-summary.js` — exported the existing `sortFinancialYears` function (previously private)
- `src/routes/models/search/results.js` — imported `sortFinancialYears` and applied it in the `getYears` filter helper so both dynamic years (from backend) and the static fallback are sorted in ascending financial year order
- `test/unit/routes/models/search/results.test.js` — added a test asserting out-of-order years from the backend are returned in ascending order