### PR TITLE
Reduce dev pulse timeout

### DIFF
--- a/src/common/helpers/pulse.js
+++ b/src/common/helpers/pulse.js
@@ -1,13 +1,15 @@
 import hapiPulse from 'hapi-pulse'
 import { createLogger } from './logging/logger.js'
+import { config } from '../../config/config.js'
 
 const tenSeconds = 10 * 1000
+const oneSecond = 1 * 1000
 
 const pulse = {
   plugin: hapiPulse,
   options: {
     logger: createLogger(),
-    timeout: tenSeconds
+    timeout: config.get('isDevelopment') ? oneSecond : tenSeconds
   }
 }
 


### PR DESCRIPTION
\`hapi-pulse\` handles \`SIGTERM\` by calling \`server.stop()\` and waiting for existing connections to drain before calling \`process.exit()\`. The default 10-second timeout means that when Node.js \`--watch\` mode triggers a restart, the old process can remain alive (holding its port) for up to 10 seconds while waiting for keep-alive browser connections to close. If the new process starts and attempts to bind the port before the old one exits, an \`EADDRINUSE\` error occurs and the restart fails.

In development (\`NODE_ENV=development\`), graceful connection draining is not a concern. This change reduces the timeout to 1 second, ensuring the old process exits quickly on each watch restart.