### PR TITLE
Handle back on cookie withdrawal

### DIFF
--- a/src/client/javascripts/cookies.js
+++ b/src/client/javascripts/cookies.js
@@ -53,6 +53,16 @@ export default {
   init () {
     this.setupCookieComponentListeners()
     this.cleanupStaleCookies()
+    this.setupBfcacheGuard()
+  },
+
+  setupBfcacheGuard () {
+    globalThis.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        deleteGoogleAnalyticsCookies()
+        globalThis.location.reload()
+      }
+    })
   },
 
   cleanupStaleCookies () {

--- a/src/plugins/cookies.js
+++ b/src/plugins/cookies.js
@@ -21,6 +21,8 @@ export const cookies = {
           statusCode !== httpConstants.HTTP_STATUS_FORBIDDEN &&
           request.response.source.context
         ) {
+          request.response.header('cache-control', 'no-store')
+
           const cookiesPolicy = getCurrentPolicy(request, h)
 
           request.response.source.context.cookiesPolicy = cookiesPolicy

--- a/src/routes/cookies.js
+++ b/src/routes/cookies.js
@@ -9,14 +9,22 @@ export const cookies = [
   {
     method: 'GET',
     path: '/cookies',
+    options: {
+      validate: {
+        query: {
+          updated: Joi.boolean().default(false),
+          referer: Joi.string().allow('').max(2000).optional()
+        }
+      }
+    },
     handler: function (request, h) {
       return h.view(
         'cookies/policy',
         {
           pageTitle: 'Cookies',
           ...cookiesModel(
-            false,
-            getRefererPath(request.headers.referer, request.info.hostname),
+            request.query.updated,
+            getRefererPath(request.query.referer ?? request.headers.referer, request.info.hostname),
             request.state[config.get('cookie.name')]
           )
         }
@@ -50,17 +58,8 @@ export const cookies = [
         return h.redirect(safeReturnUrl)
       }
 
-      return h.view(
-        'cookies/policy',
-        {
-          pageTitle: 'Cookies',
-          ...cookiesModel(
-            true,
-            getRefererPath(payload.referer, request.info.hostname),
-            request.state[config.get('cookie.name')]
-          )
-        }
-      )
+      const safeReferer = getRefererPath(payload.referer, request.info.hostname)
+      return h.redirect(`/cookies?updated=true&referer=${encodeURIComponent(safeReferer)}`)
     }
   }
 ]

--- a/test/integration/narrow/routes/cookies.test.js
+++ b/test/integration/narrow/routes/cookies.test.js
@@ -39,6 +39,11 @@ describe('Cookies route', () => {
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
   })
 
+  test('GET /cookies has Cache-Control: no-store header', async () => {
+    const result = await server.inject(getOptions('cookies', 'GET'))
+    expect(result.headers['cache-control']).toBe('no-store')
+  })
+
   test('Check for common elements', () => {
     expectPageTitle($, 'Cookies')
     expectHeader($)
@@ -181,7 +186,7 @@ describe('Cookies route', () => {
     expect(result.headers.location).toBe('/search')
   })
 
-  test('POST /cookies with external returnUrl falls through to policy view', async () => {
+  test('POST /cookies with external returnUrl redirects to /cookies?updated=true', async () => {
     const getResponse = await server.inject(getOptions('cookies', 'GET'))
     const $page = cheerio.load(getResponse.payload)
     const cookies = getResponse.headers['set-cookie']
@@ -201,11 +206,11 @@ describe('Cookies route', () => {
       }
     })
 
-    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(result.request.response.source.template).toBe('cookies/policy')
+    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
+    expect(result.headers.location).toBe('/cookies?updated=true&referer=%2F')
   })
 
-  test('POST /cookies with protocol-relative returnUrl falls through to policy view', async () => {
+  test('POST /cookies with protocol-relative returnUrl redirects to /cookies?updated=true', async () => {
     const getResponse = await server.inject(getOptions('cookies', 'GET'))
     const $page = cheerio.load(getResponse.payload)
     const cookies = getResponse.headers['set-cookie']
@@ -225,8 +230,8 @@ describe('Cookies route', () => {
       }
     })
 
-    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(result.request.response.source.template).toBe('cookies/policy')
+    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
+    expect(result.headers.location).toBe('/cookies?updated=true&referer=%2F')
   })
 
   test('POST /cookies fallback sanitizes an unsafe referer back link to /', async () => {
@@ -235,7 +240,7 @@ describe('Cookies route', () => {
     const cookies = getResponse.headers['set-cookie']
     const crumb = $page('input[name="crumb"]').val()
 
-    const result = await server.inject({
+    const postResult = await server.inject({
       method: 'POST',
       url: '/cookies',
       headers: {
@@ -250,12 +255,29 @@ describe('Cookies route', () => {
       }
     })
 
-    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(result.request.response.source.template).toBe('cookies/policy')
+    expect(postResult.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
 
-    const payload = result.payload
-    const $payload = cheerio.load(payload)
+    const getResult = await server.inject({
+      method: 'GET',
+      url: postResult.headers.location,
+      headers: {
+        cookie: postResult.headers['set-cookie']
+          ? [postResult.headers['set-cookie']].flat().join(';')
+          : ''
+      }
+    })
+
+    expect(getResult.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
+    const $payload = cheerio.load(getResult.payload)
     expectBackLink($payload, '/', 'Back')
+  })
+
+  test('GET /cookies?updated=true renders success notification banner', async () => {
+    const result = await server.inject({ method: 'GET', url: '/cookies?updated=true' })
+    const $page = cheerio.load(result.payload)
+
+    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
+    expect($page('.govuk-notification-banner--success').length).toBe(1)
   })
 
   test('POST /cookies with returnUrl exceeding 2000 chars returns 400', async () => {

--- a/test/integration/narrow/routes/cookies.test.js
+++ b/test/integration/narrow/routes/cookies.test.js
@@ -233,7 +233,7 @@ describe('Cookies route', () => {
     const $page = cheerio.load(result.payload)
 
     expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect($page('.govuk-notification-banner--success').length).toBe(1)
+    expect($page('.govuk-notification-banner--success')).toHaveLength(1)
   })
 
   test('POST /cookies with returnUrl exceeding 2000 chars returns 400', async () => {

--- a/test/integration/narrow/routes/cookies.test.js
+++ b/test/integration/narrow/routes/cookies.test.js
@@ -162,7 +162,11 @@ describe('Cookies route', () => {
     expectPhaseBanner($)
   })
 
-  test('POST /cookies with valid returnUrl redirects to that URL', async () => {
+  test.each([
+    { label: 'valid returnUrl', returnUrl: '/search', expectedLocation: '/search' },
+    { label: 'external returnUrl', returnUrl: 'https://evil.example.com', expectedLocation: '/cookies?updated=true&referer=%2F' },
+    { label: 'protocol-relative returnUrl', returnUrl: '//evil.example.com', expectedLocation: '/cookies?updated=true&referer=%2F' }
+  ])('POST /cookies with $label redirects to $expectedLocation', async ({ returnUrl, expectedLocation }) => {
     const getResponse = await server.inject(getOptions('cookies', 'GET'))
     const $page = cheerio.load(getResponse.payload)
     const cookies = getResponse.headers['set-cookie']
@@ -177,61 +181,13 @@ describe('Cookies route', () => {
       payload: {
         analytics: true,
         async: false,
-        returnUrl: '/search',
+        returnUrl,
         crumb
       }
     })
 
     expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
-    expect(result.headers.location).toBe('/search')
-  })
-
-  test('POST /cookies with external returnUrl redirects to /cookies?updated=true', async () => {
-    const getResponse = await server.inject(getOptions('cookies', 'GET'))
-    const $page = cheerio.load(getResponse.payload)
-    const cookies = getResponse.headers['set-cookie']
-    const crumb = $page('input[name="crumb"]').val()
-
-    const result = await server.inject({
-      method: 'POST',
-      url: '/cookies',
-      headers: {
-        cookie: cookies ? cookies.join(';') : ''
-      },
-      payload: {
-        analytics: true,
-        async: false,
-        returnUrl: 'https://evil.example.com',
-        crumb
-      }
-    })
-
-    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
-    expect(result.headers.location).toBe('/cookies?updated=true&referer=%2F')
-  })
-
-  test('POST /cookies with protocol-relative returnUrl redirects to /cookies?updated=true', async () => {
-    const getResponse = await server.inject(getOptions('cookies', 'GET'))
-    const $page = cheerio.load(getResponse.payload)
-    const cookies = getResponse.headers['set-cookie']
-    const crumb = $page('input[name="crumb"]').val()
-
-    const result = await server.inject({
-      method: 'POST',
-      url: '/cookies',
-      headers: {
-        cookie: cookies ? cookies.join(';') : ''
-      },
-      payload: {
-        analytics: false,
-        async: false,
-        returnUrl: '//evil.example.com',
-        crumb
-      }
-    })
-
-    expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_FOUND)
-    expect(result.headers.location).toBe('/cookies?updated=true&referer=%2F')
+    expect(result.headers.location).toBe(expectedLocation)
   })
 
   test('POST /cookies fallback sanitizes an unsafe referer back link to /', async () => {

--- a/test/unit/client/javascripts/cookies.test.js
+++ b/test/unit/client/javascripts/cookies.test.js
@@ -11,6 +11,7 @@ describe('cookies', () => {
     globalThis.document = dom.window.document
     globalThis.window = dom.window
     globalThis.location = dom.window.location
+    globalThis.addEventListener = (...args) => dom.window.addEventListener(...args)
   })
 
   beforeEach(() => {
@@ -298,5 +299,46 @@ describe('cookies', () => {
     cookies.init()
 
     expect(document.cookie).toContain('_ga=GA1')
+  })
+})
+
+describe('cookies — setupBfcacheGuard', () => {
+  let reloadSpy
+  let pageshowHandler
+
+  beforeEach(() => {
+    reloadSpy = vi.fn()
+    vi.stubGlobal('location', { hostname: 'localhost', reload: reloadSpy })
+
+    document.cookie = '_ga=GA1.2.123456789.1234567890'
+
+    // Spy on addEventListener so we can capture the exact handler this
+    // call registers, rather than dispatching an event that would trigger
+    // all accumulated pageshow listeners from earlier tests.
+    const addEventListenerSpy = vi.spyOn(dom.window, 'addEventListener')
+    cookies.setupBfcacheGuard()
+    const pageshowCall = addEventListenerSpy.mock.calls.find(([event]) => event === 'pageshow')
+    pageshowHandler = pageshowCall?.[1]
+    addEventListenerSpy.mockRestore()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  test('reloads on bfcache restore (persisted = true)', () => {
+    pageshowHandler({ persisted: true })
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  test('does not reload on normal page load (persisted = false)', () => {
+    pageshowHandler({ persisted: false })
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  test('clears GA cookies before reload on bfcache restore', () => {
+    pageshowHandler({ persisted: true })
+    expect(document.cookie).not.toContain('_ga=GA1')
   })
 })


### PR DESCRIPTION
## Problem

After a user withdraws cookie consent on `/cookies` and clicks **Back**, the browser restores a cached page that was rendered while `analytics: true`. The GTM snippet in that cached page re-executes, re-enabling tracking. This repeats until any fresh navigation triggers a server refetch.

Additionally, after submitting the preferences form the browser showed an `ERR_CACHE_MISS` / "Resubmit the form?" dialog on Back because the POST response was rendered as a view with no cache policy.

## Changes

### `src/plugins/cookies.js`
Adds `Cache-Control: no-store` to all view responses in `onPreResponse`. Prevents the browser caching consent-sensitive pages and makes them ineligible for the back/forward cache (bfcache), forcing a server refetch that renders the correct state.

### `src/routes/cookies.js`
Applies the **Post/Redirect/Get** pattern to the POST `/cookies` sync fallback (unsafe/missing `returnUrl`). Redirects to `/cookies?updated=true&referer=<safe-path>` instead of rendering a view directly. This:
- Eliminates the `ERR_CACHE_MISS` / resubmit dialog on Back
- Preserves the back link by carrying the sanitised referer through the redirect query string

GET `/cookies` gains query validation for `updated` and `referer`, and prefers `request.query.referer` over the HTTP Referer header so the back link renders correctly after redirect.

### `src/client/javascripts/cookies.js`
Adds `setupBfcacheGuard()` as defence-in-depth: a `pageshow` listener that deletes GA cookies and reloads when `event.persisted` is `true` (bfcache restore), covering browsers that may restore pages despite `no-store`.

### Tests
- Integration: updated the two "falls through to policy view" tests and the "unsafe referer back link" test to reflect the PRG redirect; added `Cache-Control: no-store` assertion and `GET /cookies?updated=true` success banner assertion
- Unit: extended the existing jsdom client cookies test with a `setupBfcacheGuard` suite; wired `globalThis.addEventListener` via `dom.window` in `beforeAll` so the handler is correctly captured and exercised