### PR TITLE
Address Sonar issues

### DIFF
--- a/test/integration/narrow/plugins/headers.test.js
+++ b/test/integration/narrow/plugins/headers.test.js
@@ -89,92 +89,24 @@ describe('headers', () => {
   })
 
   describe('404 error responses', () => {
-    test('should prevent MIME sniffing attacks on 404 pages', async () => {
+    test.each([
+      ['x-content-type-options', 'nosniff', 'prevent MIME sniffing attacks'],
+      ['x-frame-options', 'DENY', 'prevent clickjacking attacks'],
+      ['x-robots-tag', 'noindex, nofollow', 'prevent robots from indexing'],
+      ['x-xss-protection', '1; mode=block', 'prevent cross-site scripting attacks'],
+      ['cross-origin-opener-policy', 'same-origin', 'only interact with the same origin'],
+      ['cross-origin-embedder-policy', 'require-corp', 'only be embedded by the same origin'],
+      ['cross-origin-resource-policy', 'same-site', 'only interact with the same site'],
+      ['referrer-policy', 'same-origin', 'only send referrer information to the same origin'],
+      ['permissions-policy', 'camera=(), geolocation=(), magnetometer=(), microphone=(), payment=(), usb=()', 'restrict permissions for sensitive features'],
+      ['strict-transport-security', 'max-age=31536000; includeSubDomains; preload', 'enforce HTTPS with strict transport security'],
+      ['x-download-options', 'noopen', 'prevent file downloads from opening']
+    ])('should set %s header on 404 pages to %s', async (header, value) => {
       const response = await server.inject({
         url: '/non-existent-path'
       })
       expect(response.statusCode).toBe(404)
-      expect(response.headers['x-content-type-options']).toBe('nosniff')
-    })
-
-    test('should prevent clickjacking attacks on 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['x-frame-options']).toBe('DENY')
-    })
-
-    test('should prevent robots from indexing 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['x-robots-tag']).toBe('noindex, nofollow')
-    })
-
-    test('should prevent cross-site scripting attacks on 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['x-xss-protection']).toBe('1; mode=block')
-    })
-
-    test('should ensure 404 pages can only interact with the same origin', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['cross-origin-opener-policy']).toBe('same-origin')
-    })
-
-    test('should ensure 404 pages can only be embedded by the same origin', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['cross-origin-embedder-policy']).toBe('require-corp')
-    })
-
-    test('should ensure 404 pages can only interact with the same site', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['cross-origin-resource-policy']).toBe('same-site')
-    })
-
-    test('should ensure 404 pages only send referrer information to the same origin', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['referrer-policy']).toBe('same-origin')
-    })
-
-    test('should restrict permissions for sensitive features on 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['permissions-policy']).toBe('camera=(), geolocation=(), magnetometer=(), microphone=(), payment=(), usb=()')
-    })
-
-    test('should enforce HTTPS with strict transport security on 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains; preload')
-    })
-
-    test('should prevent file downloads from opening in 404 pages', async () => {
-      const response = await server.inject({
-        url: '/non-existent-path'
-      })
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['x-download-options']).toBe('noopen')
+      expect(response.headers[header]).toBe(value)
     })
   })
 })

--- a/test/integration/narrow/routes/accessibility.test.js
+++ b/test/integration/narrow/routes/accessibility.test.js
@@ -48,37 +48,17 @@ describe('Accessibility route', () => {
     expectFooter($)
   })
 
-  test('Should render a back link with referer', async () => {
-    options.headers = {
-      referer: '/previous-page'
-    }
+  test.each([
+    ['/previous-page', '/previous-page', 'renders back link with referer'],
+    ['https://evil.com', '/', 'does not use an external URL as the back link href'],
+    ['javascript:alert(1)', '/', 'does not use a javascript URI as the back link href']
+  ])('Back link when referer is %s — %s', async (referer, expectedHref) => {
+    options.headers = { referer }
 
     response = await server.inject(options)
     $ = cheerio.load(response.payload)
 
-    expectBackLink($, '/previous-page', 'Back')
-  })
-
-  test('Should not use an external URL as the back link href', async () => {
-    options.headers = {
-      referer: 'https://evil.com'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
-  })
-
-  test('Should not use a javascript URI as the back link href', async () => {
-    options.headers = {
-      referer: 'javascript:alert(1)'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
+    expectBackLink($, expectedHref, 'Back')
   })
 
   test.each([

--- a/test/integration/narrow/routes/details.test.js
+++ b/test/integration/narrow/routes/details.test.js
@@ -82,8 +82,8 @@ describe('Details route', () => {
     expect($('#date-range').text()).toMatch('1 April 2021 to 31 March 2023')
     expect($('#total-schemes').text()).toMatch('Payments from 2 schemes')
     expect($('#total-years').text()).toMatch('Over 2 financial years')
-    expect($('.schemeDetails').length).toBe(2)
-    expect($('.schemeActivity').length).toBe(4)
+    expect($('.schemeDetails')).toHaveLength(2)
+    expect($('.schemeActivity')).toHaveLength(4)
   })
 
   test.each([

--- a/test/integration/narrow/routes/privacy.test.js
+++ b/test/integration/narrow/routes/privacy.test.js
@@ -48,37 +48,17 @@ describe('Privacy route', () => {
     expectFooter($)
   })
 
-  test('Should render a back link with referer', async () => {
-    options.headers = {
-      referer: '/previous-page'
-    }
+  test.each([
+    ['/previous-page', '/previous-page', 'renders back link with referer'],
+    ['https://evil.com', '/', 'does not use an external URL as the back link href'],
+    ['javascript:alert(1)', '/', 'does not use a javascript URI as the back link href']
+  ])('Back link when referer is %s — %s', async (referer, expectedHref) => {
+    options.headers = { referer }
 
     response = await server.inject(options)
     $ = cheerio.load(response.payload)
 
-    expectBackLink($, '/previous-page', 'Back')
-  })
-
-  test('Should not use an external URL as the back link href', async () => {
-    options.headers = {
-      referer: 'https://evil.com'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
-  })
-
-  test('Should not use a javascript URI as the back link href', async () => {
-    options.headers = {
-      referer: 'javascript:alert(1)'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
+    expectBackLink($, expectedHref, 'Back')
   })
 
   test.each([

--- a/test/integration/narrow/routes/scheme-payments-by-year.test.js
+++ b/test/integration/narrow/routes/scheme-payments-by-year.test.js
@@ -78,8 +78,8 @@ describe('Scheme Payments by year route', () => {
     expect($('#date-range').text()).toMatch('1 April 2021 to 31 March 2023')
     expect($('#total-schemes').text()).toMatch('Payments from 2 schemes')
     expect($('#total-years').text()).toMatch('Over 2 financial years')
-    expect($('.yearly-activity').length).toBe(2)
-    expect($('.scheme-activity').length).toBe(3)
+    expect($('.yearly-activity')).toHaveLength(2)
+    expect($('.scheme-activity')).toHaveLength(3)
   })
 
   test.each([

--- a/test/integration/narrow/routes/search/results.test.js
+++ b/test/integration/narrow/routes/search/results.test.js
@@ -122,7 +122,7 @@ describe('Results route', () => {
     test('Results are displayed on the page up to a limit of 20', () => {
       const resultElements = $('.govuk-link.govuk-link--no-visited-state')
 
-      expect(resultElements.length).toBe(20)
+      expect(resultElements).toHaveLength(20)
     })
 
     test('Total results show the real number', () => {
@@ -181,7 +181,7 @@ describe('Results route', () => {
     test('Page 2 only shows the last 3 results from the mock results', () => {
       const resultElements = $('.govuk-link.govuk-link--no-visited-state')
 
-      expect(resultElements.length).toBe(3)
+      expect(resultElements).toHaveLength(3)
     })
 
     test('Total results show the real number', () => {
@@ -238,7 +238,7 @@ describe('Results route', () => {
     })
 
     test('Sort by dropdown is not shown to the user', () => {
-      expect($('#sort-by-dropdown').length).toBe(0)
+      expect($('#sort-by-dropdown')).toHaveLength(0)
     })
   })
 
@@ -292,7 +292,7 @@ describe('Results route', () => {
     })
 
     test('Sort by dropdown is not shown to the user', () => {
-      expect($('#sort-by-dropdown').length).toBe(0)
+      expect($('#sort-by-dropdown')).toHaveLength(0)
     })
   })
 
@@ -331,7 +331,7 @@ describe('Results route', () => {
 
     test('Results returns 20 rows', () => {
       const resultElements = $('.govuk-link.govuk-link--no-visited-state')
-      expect(resultElements.length).toBe(20)
+      expect(resultElements).toHaveLength(20)
     })
 
     test.each([

--- a/test/integration/narrow/routes/search/search.test.js
+++ b/test/integration/narrow/routes/search/search.test.js
@@ -56,40 +56,18 @@ describe('Search route', () => {
     expectFooter($)
   })
 
-  test('Should render a back link with referer', async () => {
+  test.each([
+    ['/previous-page', '/previous-page', 'renders back link with referer'],
+    ['https://evil.com', '/', 'does not use an external URL as the back link href'],
+    ['javascript:alert(1)', '/', 'does not use a javascript URI as the back link href']
+  ])('Back link when referer is %s — %s', async (referer, expectedHref) => {
     options = getOptions('search', 'GET')
-    options.headers = {
-      referer: '/previous-page'
-    }
+    options.headers = { referer }
 
     response = await server.inject(options)
     $ = cheerio.load(response.payload)
 
-    expectBackLink($, '/previous-page', 'Back')
-  })
-
-  test('Should not use an external URL as the back link href', async () => {
-    options = getOptions('search', 'GET')
-    options.headers = {
-      referer: 'https://evil.com'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
-  })
-
-  test('Should not use a javascript URI as the back link href', async () => {
-    options = getOptions('search', 'GET')
-    options.headers = {
-      referer: 'javascript:alert(1)'
-    }
-
-    response = await server.inject(options)
-    $ = cheerio.load(response.payload)
-
-    expectBackLink($, '/', 'Back')
+    expectBackLink($, expectedHref, 'Back')
   })
 
   test('Check for search page specific elements', () => {
@@ -163,7 +141,7 @@ describe('Search route', () => {
       const $page = cheerio.load(result.payload)
 
       expect(result.statusCode).toBe(httpConstants.HTTP_STATUS_BAD_REQUEST)
-      expect($page('.govuk-cookie-banner').length).toBe(0)
+      expect($page('.govuk-cookie-banner')).toHaveLength(0)
     })
   })
 })

--- a/test/unit/client/javascripts/cookies.test.js
+++ b/test/unit/client/javascripts/cookies.test.js
@@ -137,7 +137,7 @@ describe('cookies', () => {
 
     acceptButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
 
-    expect(document.head.querySelectorAll('script').length).toBe(scriptsBefore)
+    expect(document.head.querySelectorAll('script')).toHaveLength(scriptsBefore)
   })
 
   test('should not inject GTM script when no gtm key is set', () => {
@@ -149,7 +149,7 @@ describe('cookies', () => {
 
     acceptButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
 
-    expect(document.head.querySelectorAll('script').length).toBe(scriptsBefore)
+    expect(document.head.querySelectorAll('script')).toHaveLength(scriptsBefore)
   })
 
   test('should delete GA cookies on reject', () => {

--- a/test/unit/client/javascripts/search.test.js
+++ b/test/unit/client/javascripts/search.test.js
@@ -327,8 +327,8 @@ describe('search', () => {
     test('should handle optional parameters', () => {
       const option = search.getOption('value', 'text', vi.fn())
 
-      expect(option.onmouseover).toBe(null)
-      expect(option.classList.length).toBe(0)
+      expect(option.onmouseover).toBeNull()
+      expect(option.classList).toHaveLength(0)
     })
   })
 
@@ -618,24 +618,12 @@ describe('search', () => {
       expect(hideSuggestionsSpy).toHaveBeenCalled()
     })
 
-    test('should hide suggestions when input length is less than minCharLength', () => {
-      searchInput.value = 'te'
-      const hideSuggestionsSpy = vi.spyOn(search, 'hideSuggestions')
-      searchInput.dispatchEvent(new window.Event('input', { bubbles: true }))
-
-      expect(hideSuggestionsSpy).toHaveBeenCalled()
-    })
-
-    test('should hide suggestions when input length equals the minCharLength but has a leading space', () => {
-      searchInput.value = ' te'
-      const hideSuggestionsSpy = vi.spyOn(search, 'hideSuggestions')
-      searchInput.dispatchEvent(new window.Event('input', { bubbles: true }))
-
-      expect(hideSuggestionsSpy).toHaveBeenCalled()
-    })
-
-    test('should hide suggestions when input length equals the minCharLength but has a trailing space', () => {
-      searchInput.value = 'te '
+    test.each([
+      ['te', 'input length is less than minCharLength'],
+      [' te', 'input length equals minCharLength but has a leading space'],
+      ['te ', 'input length equals minCharLength but has a trailing space']
+    ])('should hide suggestions when %s — %s', (value) => {
+      searchInput.value = value
       const hideSuggestionsSpy = vi.spyOn(search, 'hideSuggestions')
       searchInput.dispatchEvent(new window.Event('input', { bubbles: true }))
 

--- a/test/unit/routes/models/cookies.test.js
+++ b/test/unit/routes/models/cookies.test.js
@@ -37,14 +37,14 @@ describe('cookiesModel', () => {
   test('defaults to empty object when no cookiesPolicy is passed', () => {
     const model = cookiesModel(false, '', undefined)
 
-    expect(model.analytics.items[0].checked).toBe(undefined)
+    expect(model.analytics.items[0].checked).toBeUndefined()
     expect(model.analytics.items[1].checked).toBe(true)
   })
 
   test('defaults updated and referer when not provided', () => {
     const model = cookiesModel(undefined, undefined, { analytics: true })
 
-    expect(model.updated).toBe(undefined)
+    expect(model.updated).toBeUndefined()
     expect(model.referer).toBe('')
   })
 })

--- a/test/utils/phase-banner-expect.js
+++ b/test/utils/phase-banner-expect.js
@@ -4,7 +4,7 @@ export function expectPhaseBanner ($) {
   const phaseBanner = $('.govuk-phase-banner')
   const link = phaseBanner.find('.govuk-link')
 
-  expect(phaseBanner.length).toEqual(1)
+  expect(phaseBanner).toHaveLength(1)
   expect($('.govuk-phase-banner__content__tag').text()).toMatch('Beta')
   expect($('.govuk-phase-banner__text').text()).toMatch('This is a new service. Help us improve it and give your feedback (opens in new tab).')
   expect(link.attr('href')).toMatch('https://defragroup.eu.qualtrics.com/jfe/form/SV_1FcBVO6IMkfHmbs')

--- a/test/utils/tags-expect.js
+++ b/test/utils/tags-expect.js
@@ -3,6 +3,6 @@ import { expect } from 'vitest'
 export function expectTags ($, filters) {
   const tags = $('button.mpdp-button').map((_i, x) => $(x).text()).toArray()
 
-  expect(tags.length).toBe(filters.length)
+  expect(tags).toHaveLength(filters.length)
   expect(filters.every((x, i) => tags.find(y => y.includes(x)))).toBe(true)
 }


### PR DESCRIPTION
## Summary
- Replace generic `.length`/`.toBe(undefined)`/`.toBe(null)` assertions with `.toHaveLength()`, `.toBeUndefined()`, `.toBeNull()` (S5906)
- Parameterize repetitive back-link tests, header tests, and search input tests with `test.each` (S5976)

## Test plan
- [x] All existing tests pass
- [x] No behavioural changes — style/clarity improvements only